### PR TITLE
Fix window resizing on wayland

### DIFF
--- a/src/murg/elements/generic.cr
+++ b/src/murg/elements/generic.cr
@@ -91,7 +91,7 @@ module Murg
             Engine.instance.handle_event(generic_attributes.id, event.event_type.to_s.camelcase(lower: true), nil)
           end
 
-          true
+          false
         end
 
         widget.add_controller(event_controller)


### PR DESCRIPTION
Apparently you can't resize the window on wayland (due to `register_events`'s `event_signal` returning `true`) 😅

(xeyes to showcase whether the window is under xwayland (it can only track the cursor only on x11/xwayland))

- Wayland, before this PR

[A video recording of GNOME desktop showcasing the example murg app and xeyes on the bottom left. The cursor first moves around inside the murg app window - xeyes are not moving. Then it tries unsuccessfully to resize the window.](https://user-images.githubusercontent.com/18014039/198415180-c3a4a57b-947c-4c93-907b-52a1dda50829.webm)

- Xwayland, before this PR

[A video recording of GNOME desktop showcasing the example murg app and xeyes on the bottom left. The cursor first moves around inside the murg app window - xeyes are moving following the cursor position. Then it tries successfully to resize the window.](https://user-images.githubusercontent.com/18014039/198415546-d8bddc32-f245-469c-94d8-f03afc29b9ee.webm)

- Wayland, after this PR

[A video recording of GNOME desktop showcasing the example murg app and xeyes on the bottom left. The cursor first moves around inside the murg app window - xeyes are not moving. Then it tries successfully to resize the window.](https://user-images.githubusercontent.com/18014039/198415771-40b69738-6b46-4f52-96f8-fee4b3d0e055.webm)

